### PR TITLE
Filter for ArrayObject, SplObjectStorage collections and associative collections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "files": [
           "src/Internal/_functions.php",
           "src/Internal/_stream.php",
+           "src/Internal/_IteratorAdapter.php",
           "src/functions.php",
           "src/operators.php",
           "src/common.php",

--- a/src/Internal/_IteratorAdapter.php
+++ b/src/Internal/_IteratorAdapter.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * functional: _IteratorAdapter.php
+ */
+
+namespace Tarsana\Functional;
+
+/**
+ * Provides an Iterator for a given associative SplObjectStorage collection which accesses the collection members like an ArrayIterator.
+ * Class _IteratorAdapter
+ * @package Tarsana\Functional
+ * @internal
+ */
+class _IteratorAdapter implements \Iterator
+{
+	private $objectStorage;
+
+	public function __construct(\SplObjectStorage $theObjectStorage)
+	{
+		$this->objectStorage = $theObjectStorage;
+	}
+
+	/**
+	 * Return the current element
+	 * @link http://php.net/manual/en/iterator.current.php
+	 * @return mixed Can return any type.
+	 * @since 5.0.0
+	 */
+	public function current()
+	{
+		return $this->objectStorage->getInfo();
+	}
+
+	/**
+	 * Move forward to next element
+	 * @link http://php.net/manual/en/iterator.next.php
+	 * @return void Any returned value is ignored.
+	 * @since 5.0.0
+	 */
+	public function next()
+	{
+		return $this->objectStorage->next();
+	}
+
+	/**
+	 * Return the key of the current element
+	 * @link http://php.net/manual/en/iterator.key.php
+	 * @return mixed scalar on success, or null on failure.
+	 * @since 5.0.0
+	 */
+	public function key()
+	{
+		return $this->objectStorage->current();
+	}
+
+	/**
+	 * Checks if current position is valid
+	 * @link http://php.net/manual/en/iterator.valid.php
+	 * @return boolean The return value will be casted to boolean and then evaluated.
+	 * Returns true on success or false on failure.
+	 * @since 5.0.0
+	 */
+	public function valid()
+	{
+		return $this->objectStorage->valid();
+	}
+
+	/**
+	 * Rewind the Iterator to the first element
+	 * @link http://php.net/manual/en/iterator.rewind.php
+	 * @return void Any returned value is ignored.
+	 * @since 5.0.0
+	 */
+	public function rewind()
+	{
+		return $this->objectStorage->rewind();
+	}
+}

--- a/src/Internal/_functions.php
+++ b/src/Internal/_functions.php
@@ -312,3 +312,13 @@ function _fill_placeholders($args, $fillers) {
     }
     return $args;
 }
+
+function _iterable_reduce(callable $reducer, $acc, \Iterator $iterator) {
+	$iterator->rewind();
+	while ($iterator->valid()) {
+		$acc = $reducer($acc, $iterator->current(), $iterator->key());
+		$iterator->next();
+	}
+	return $acc;
+}
+

--- a/src/list.php
+++ b/src/list.php
@@ -149,7 +149,7 @@ function _make_filterer (callable $append, callable $predicate) {
  * //}
  * ```
  *
- * @signature (a -> Boolean) -> [a] -> [a]
+ * @signature (a -> Boolean) -> {k: a} -> {k: a}
  * @param callable $predicate
  * @param array|\ArrayObject|\SplObjectStorage $list
  * @return array|\ArrayObject|\SplObjectStorage|callable

--- a/tests/Internal/FunctionsTest.php
+++ b/tests/Internal/FunctionsTest.php
@@ -62,5 +62,22 @@ class FunctionsTest extends \Tarsana\UnitTests\Functional\UnitTest {
 		$newArgs = F\_merge_args($given, $args, 4);
 		$this->assertEquals((object) ['args' => [1, 2, 3, F\__()], 'placeholders' => 1], $newArgs);
 	}
+
+	public function test__iterable_reduce() {
+		$xs = [1, 2, 3];
+		$this->assertEquals(F\sum($xs),
+			F\_iterable_reduce('Tarsana\Functional\plus', 0, new \ArrayIterator($xs)));
+
+		$xs_assoc = [1 => "one", 2 => "two", 3 => "three"];
+		$this->assertEquals("1=>one,2=>two,3=>three,",
+			F\_iterable_reduce(
+				function ($acc, $value, $key) {
+					return $acc . "{$key}=>{$value},";
+				},
+				"",
+				new \ArrayIterator($xs_assoc)
+			)
+		);
+	}
 }
 

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -5,7 +5,7 @@ use Tarsana\Functional as F;
 /**
  * The parent class for unit tests.
  */
-abstract class UnitTest extends \PHPUnit_Framework_TestCase {
+abstract class UnitTest extends \PHPUnit\Framework\TestCase {
     /**
      * Checks all assertions.
      * @param  array $assertions [[expected1, value1], [expected2, value2], ...]


### PR DESCRIPTION
This is a first attempt to add `ArrayObject` and `SplObjectStorage` to the list of supported collections.

In difference to [Ramda](http://ramdajs.com/) for JavaScript I decided to provide a separate `filter_values` function for associative collections. Thus user of the library must explicitly choose the appropriate function suitable for his type of data. 

This is because in PHP [determining that a collection is associative or not](http://stackoverflow.com/questions/5996749/determine-whether-an-array-is-associative-hash-or-not) seems to be [quite expensive](https://gist.github.com/Thinkscape/1965669).  

- `filter` now works on non-associative `ArrayObject` and the object items of `SplObjectStorage`.
- `filter_values` works on associative `array`, the values in  `ArrayObject` and the data items of `SplObjectStorage`. This is in the same spirit as *Ramda's* `filter` works on JavaScript dictionary objects `{key: "value", key2: "value2"}`.

The implementation is based on a new internal reduce algorithm `_iterable_reduce()` for `Iterators`. By providing another reducer to `_iterable_reduce` `map` can be extended for other collections as well.

How do I generate the documentation markdown files?